### PR TITLE
Update setuptools/wheel before installing petlib

### DIFF
--- a/pets-master/Dockerfile
+++ b/pets-master/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
   libssl-dev \
   libffi-dev
 
+RUN pip install --upgrade pip setuptools wheel
 RUN pip install petlib pytest
 
 VOLUME ["/src"]


### PR DESCRIPTION
Installation of petlib/pytest seems to fail due to errors with setuptools. Updating setuptools before the installation seems to resolve the issue.